### PR TITLE
Add sphinx_rtd_theme to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 toml
+sphinx_rtd_theme


### PR DESCRIPTION
This adds sphinx RTD theme to the list of docs requirements.