### PR TITLE
Constraint xlwings version to match VBA standalone module

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -109,6 +109,10 @@ To set up the EP interface, follow these steps:
         | Interpreter_Mac |  /Users/Username/miniconda3/envs/ep/bin/python |
         +-----------------+------------------------------------------------+
 
+    With the EP conda environment activated in the terminal, run the following command to finalize the installation of the xlwings package::
+
+        (ep) $ xlwings runpython install
+
 2. Data Setup
 -------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - matplotlib
   - click
   - sphinx_rtd_theme
-  - xlwings
+  - xlwings=0.30.15
   - conda-forge::numpy-financial
   - conda-forge::pint
   - conda-forge::toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     'sphinx_rtd_theme',
     'toml',
     "csvdb@git+https://github.com/EvolvedEnergyResearch/csvdb",
-    "xlwings",
+    "xlwings==0.30.15",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "energyPATHWAYS"
-version = '2024.03.15'
+version = '2024.07.22'
 authors = [
     { name = "Ben Haley"},
     { name = "Ryan Jones"},


### PR DESCRIPTION
This PR:
1. fixes the version of xlwings downloaded during the EP installation to match the version in the VBA standalone module.
2. updates the documentation.